### PR TITLE
fix: remove depthBuffer

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,7 +77,7 @@ else
 		scene.background = new t.Color(0.0);
 		scene.add( camera );
 
-		renderer = new t.WebGLRenderer({antialias: true, depthBuffer: true});
+		renderer = new t.WebGLRenderer({antialias: true});
 		renderer.setPixelRatio(pixR);
 	    
 	  	world = new t.Object3D();


### PR DESCRIPTION
depthBuffer was removed as it appears to be used by WebGLRenderTarget.

related document
[WebGLRenderer](https://threejs.org/docs/#api/en/renderers/WebGLRenderer)
[WebGLRenderTarget](https://threejs.org/docs/#api/en/renderers/WebGLRenderTarget)